### PR TITLE
Allow dice to be sorted by priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Shared Dice is a Foundry VTT module that allows Game Masters to give players var
 - **Management:** Users with editing permissions can easily add or remove dice from players directly through the player list interface.
 - **Player Usage:** Players can expend their own dice or gift dice from their own pool to other players.
 - **Customizable Chat Messages:** Tailor the chat messages for actions like adding, removing, using, or gifting dice. Messages are configured per dice type and per action.
-- **Dynamic UI:** Intelligently handles large number of different dice types by collapsing additional dice types beyond the initial display count into an expandable overflow section in the player list.
+- **Dynamic UI:** Intelligently handles large number of different dice types by collapsing additional dice types beyond the initial display count into an expandable overflow section in the player list. The sorting can be configured via settings.
 
 # Installation
 
@@ -22,6 +22,7 @@ The primary configuration for this module involves defining the different **Dice
 - **Image:** An icon to represent the die in the UI.
 - **Enabled:** A checkbox to control if this dice type is currently active. Disabled dice are hidden and not usable but their data is preserved and they can be reenabled at any time. This allows you to temporarily remove a dice type without losing player counts or its specific configurations.
 - **Limit:** The maximum number of this dice type a player can hold.
+- **Sort Priority:** Determines the order in which dice are displayed on the player list. Dice with a higher priority are displayed closer to the user names.
 - **Message Templates:** For each action (`add`, `remove`, `use`, `gift`), you can define a chat message template. If a template is left blank, no chat message will be sent for that specific action and dice type.
 
 ### Chat Message Placeholders

--- a/lang/en.json
+++ b/lang/en.json
@@ -47,6 +47,10 @@
                 "Label": "Maximum Amount per User",
                 "Hint": "The maximum number of dice of this type a single user can possess. (0 for unlimited)"
             },
+            "sortPriority": {
+                "Label": "Sort Priority",
+                "Hint": "Determines the order in which dice are displayed on the player list. Dice with a higher priority are displayed closer to the user names."
+            },
             "msgOnAdd": {
                 "Label": "Message on Add",
                 "Hint": "Chat message shown when a die is added to a user. If empty, no message is sent.",

--- a/scripts/classes/DiceType.mjs
+++ b/scripts/classes/DiceType.mjs
@@ -16,6 +16,7 @@ import { getSetting, setSetting } from "../settings.mjs";
  * @property {string} name                      The user-facing name for this die type (e.g., "Inspiration", "Hero Point"). Used in UI elements and chat messages via [$shareDieName].
  * @property {string} img                       The file path to the img representing this die type.
  * @property {number} maxPerUser                The maximum number of dice of this type a single user can possess. (0 for unlimited)
+ * @property {number} sortPriority              Determines the order in which dice are displayed next to the user names. Higher priority means closer to the user name.
  * @property {MessageTemplates} messages
  */
 
@@ -61,6 +62,13 @@ export default class DiceType extends foundry.abstract.DataModel {
                 label: "SHAREDDICE.Fields.maxPerUser.Label",
                 hint: "SHAREDDICE.Fields.maxPerUser.Hint",
             }),
+            sortPriority: new NumberField({
+                nullable: false,
+                initial: 0,
+                required: true,
+                label: "SHAREDDICE.Fields.sortPriority.Label",
+                hint: "SHAREDDICE.Fields.sortPriority.Hint",
+            }),
             messages: new SchemaField({
                 add: new StringField({
                     initial: () => game.i18n.localize("SHAREDDICE.Fields.msgOnAdd.Placeholder"),
@@ -86,7 +94,7 @@ export default class DiceType extends foundry.abstract.DataModel {
                     label: "SHAREDDICE.Fields.msgOnGift.Label",
                     hint: "SHAREDDICE.Fields.msgOnGift.Hint"
                 })
-            }),
+            })
         }
     }
 

--- a/scripts/classes/UIHandler.mjs
+++ b/scripts/classes/UIHandler.mjs
@@ -107,6 +107,7 @@ export default class UIHandler {
 
         const diceData = Object.values(this.#allTypes)
             .filter(typeData => typeData.enabled)
+            .sort((a, b) => b.sortPriority - a.sortPriority)
             .map(typeData => ({
                 typeData,
                 quant: userQuants[typeData.id] ?? 0

--- a/templates/DiceTypesSettingMenu.hbs
+++ b/templates/DiceTypesSettingMenu.hbs
@@ -32,6 +32,7 @@
         {{ formGroup fields.name value=die.name name="name" localize=true }}
         {{ formGroup fields.img value=die.img name="img" localize=true }}
         {{ formGroup fields.maxPerUser value=die.maxPerUser name="maxPerUser" localize=true }}
+        {{ formGroup fields.sortPriority value=die.sortPriority name="sortPriority" localize=true }}
 
     </fieldset>
     <fieldset class="dice-config">


### PR DESCRIPTION
Adds a `sortPriority` property to the DiceType data model, allowing users to define the display order of dice in the player list. Update the UIHandler to sort dice based on this priority, and the settings menu with relevant translations.