### PR TITLE
Add user flags data cleaning

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -103,7 +103,8 @@
             "onOverLimit": "Users cannot have more than {diceTypeLimit} uses of {diceTypeName}.",
             "disallowedGift": "This die cannot be gifted.",
             "missingEditPermission": "You do not have the required permissions to add or remove this die.",
-            "noActiveOwner": "No owner for the target document currently active. See console for details."
+            "noActiveOwner": "No owner for the target document currently active. See console for details.",
+            "unUserDataCleanFail": "Failed to clean the flag data of {failCount} users. See console warnings for details."
         },
         "UI": {
             "Tooltips": {

--- a/scripts/applications/DiceTypesSettingMenu.mjs
+++ b/scripts/applications/DiceTypesSettingMenu.mjs
@@ -1,7 +1,8 @@
 import DiceType from "../classes/DiceType.mjs";
+import { cleanAllUserFlagsData } from "../classes/UserHandler.mjs";
 import { MODULE_ID } from "../CONSTS.mjs";
 import { getSetting, setSetting } from "../settings.mjs";
-import { log } from "../utils.mjs";
+import { log, notify } from "../utils.mjs";
 
 /** 
  * @import FormDataExtended from "@client/applications/ux/form-data-extended.mjs" 
@@ -138,6 +139,8 @@ export default class DiceTypesSettingMenu extends HandlebarsApplicationMixin(App
         if(deleted.length && !await this.#confirmDelete(deleted)) return;
 
         await setSetting("diceTypes", this.#diceData);
+        await cleanAllUserFlagsData(true);
+
         this.close();
     }
 


### PR DESCRIPTION
Introduce functions to clean invalid user flag data and notify on failures. Implement user flags cleanup during the DiceTypeSettingMenu save process.