### PR TITLE
Update for v14 and refactor symlink script

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,21 @@ Hooks.call("shareddice.preCreateChatMessage", action, diceId, targetUser, amount
 Hooks.callAll("shareddice.createChatMessage", action, diceId, targetUser, amount, message)
 ```
 
+
+# Development Scripts
+
+### `npm run createFoundrySymlinks -- --foundry-install-path=<string>`
+Creates a `foundry/` directory in the repo root, containing symlinks to the `tsconfig.json` and the `client`, `common`, and `lang` directories of the foundry installation. These symlinks are referenced in `jsconfig.json` and used for type checking and Intellisense.
+
+**Example:** `npm run createFoundrySymlinks -- --foundry-install-path="C:\FoundryV14\foundryvtt"`
+
+| Argument                  | Type      |  Description |
+| :---                      | :---      | :--- |
+| `--foundry-install-path`  | `string`  | Absolute path to the Foundry installation directory. |
+
+**Windows Note:** Symlink creation might fail due to permissions if the terminal isn't running as Administrator and Windows Developer Mode isn't enabled.
+
+
 # Reporting Issues and Requesting Features
 
 If you are experiencing a bug or have an idea for a new feature, submit an [issue](https://github.com/belodri/shareddice/issues).

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
-        "module": "ES2022",
-        "target": "ES2022",
+        "module": "nodenext",
+        "target": "es2022",
         "lib": [
             "DOM",
             "ES2022"
@@ -11,7 +11,8 @@
             "@common/*": ["./foundry/common/*"]
         },
         "allowJs": true,
-        "moduleResolution": "Node"
+        "moduleResolution": "nodenext",
+        "types": [ "node" ]
     },
     "exclude": [
         "node_modules", 

--- a/module.json
+++ b/module.json
@@ -24,8 +24,8 @@
     "styles": ["styles/shareddice.css"],
     "compatibility": {
         "minimum": "13",
-        "verified": "13.351",
-        "maximum": "13"
+        "verified": "14.364",
+        "maximum": "14"
     },
     "url": "#{URL}#",
     "manifest": "#{MANIFEST}#",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "1.0.0",
             "license": "MIT",
             "devDependencies": {
+                "@types/node": "^26.1.1",
                 "eslint": "^9.15.0",
                 "eslint-plugin-jsdoc": "^50.5.0",
                 "fs-extra": "^11.3.0",
@@ -260,6 +261,16 @@
             "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@types/node": {
+            "version": "26.1.1",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+            "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~8.3.0"
+            }
         },
         "node_modules/acorn": {
             "version": "8.14.1",
@@ -1293,6 +1304,13 @@
             "engines": {
                 "node": ">= 0.8.0"
             }
+        },
+        "node_modules/undici-types": {
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+            "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/universalify": {
             "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "author": "David Haas <dave.belodri@gmail.com>",
     "license": "MIT",
     "devDependencies": {
+        "@types/node": "^26.1.1",
         "eslint": "^9.15.0",
         "eslint-plugin-jsdoc": "^50.5.0",
         "fs-extra": "^11.3.0",

--- a/tools/create-foundry-symlinks.mjs
+++ b/tools/create-foundry-symlinks.mjs
@@ -1,46 +1,158 @@
+/* eslint-disable jsdoc/require-jsdoc */
 import * as fs from "fs";
 import yaml from "js-yaml";
 import path from "path";
 
-console.log("Reforging Symlinks");
+/*
+    Env vars:
+    "foundry-config-path": string (default "foundry-config.yaml")
+    "dest-root-dir": string (default "foundry")
+*/
+await execute()
 
-if (fs.existsSync("foundry-config.yaml")) {
-    let fileRoot = "";
+async function execute() {
+    process.exitCode = 1;
+
+    const options = getEnvOptions();
+
+    const config = await loadConfig(options.foundryConfigPath);
+    if(!config) return;
+
+    const sourceRootDir = getSourceRootDir(config);
+    if(!sourceRootDir) return false;
+
+    await createDestinationRootDir(options.destRootDir);
+    await linkJsFiles(sourceRootDir, options.destRootDir);
+    await linkLangFiles(sourceRootDir, options.destRootDir);
+
+    console.log("Successfully created foundry symlinks.");
+    process.exitCode = 0;
+}
+
+/**
+ * @typedef {object} EnvOptions
+ * @property {string} foundryConfigPath
+ * @property {string} destRootDir
+ */
+
+function getEnvOptions() {
+    const foundryConfigPath = process.env.npm_config_foundry_config_path ?? "foundry-config.yaml";
+    const destRootDir = process.env.npm_config_dest_root_dir ?? "foundry";
+
+    /** @type {EnvOptions} */
+    const options = {
+        foundryConfigPath,
+        destRootDir
+    }
+
+    return options
+}
+
+/**
+ * @param {string} sourceRootDir 
+ * @param {string} destRootDir
+ */
+async function linkJsFiles(sourceRootDir, destRootDir) {
+    for(const p of ["client", "common", "tsconfig.json"]) {
+        const targetPath = path.join(sourceRootDir, p);
+        const symlinkPath = path.join(destRootDir, p);
+
+        const canCreate = await canCreateSymlink(targetPath, symlinkPath)
+        if(canCreate) await createSymlink(targetPath, symlinkPath);
+    }
+}
+
+async function linkLangFiles(sourceRootDir, destRootDir) {
+    const targetPath = path.join(sourceRootDir, "public", "lang");
+    const symlinkPath = path.join(destRootDir, "lang");
+
+    const canCreate = await canCreateSymlink(targetPath, symlinkPath)
+    if(canCreate) await createSymlink(targetPath, symlinkPath);
+}
+
+async function createSymlink(targetPath, symlinkPath) {
+    await fs.promises.symlink(targetPath, symlinkPath);
+    console.log(`Symlinked: ${symlinkPath} -> ${targetPath}`);
+}
+
+
+/**
+ * @typedef {object} Config
+ * @property {string} installPath
+ */
+
+/**
+ * @param {string} configYamlPath 
+ */
+async function loadConfig(configYamlPath) {
+    if(!fs.existsSync(configYamlPath)) {
+        console.error(`Config yaml file '${configYamlPath}' not found.`);
+        return;
+    }
+
     try {
-        const fc = await fs.promises.readFile("foundry-config.yaml", "utf-8");
+        const fc = await fs.promises.readFile(configYamlPath, "utf-8");
 
+        /** @type {Config} */
         const foundryConfig = yaml.load(fc);
-
-        // As of 13.338, the Node install is *not* nested but electron installs *are*
-        const nested = fs.existsSync(path.join(foundryConfig.installPath, "resources", "app"));
-
-        if (nested) fileRoot = path.join(foundryConfig.installPath, "resources", "app");
-        else fileRoot = foundryConfig.installPath;
+        return foundryConfig
     } catch (err) {
-        console.error(`Error reading foundry-config.yaml: ${err}`);
+        console.error(`Error reading ${configYamlPath}: ${err}`);
+    }
+}
+
+/**
+ * @param {Config} config 
+ */
+function getSourceRootDir(config) {
+    // As of 13.338, the Node install is not nested but electron installs are
+    const isNested = fs.existsSync(path.join(config.installPath, "resources", "app"));
+
+    const root = isNested 
+        ? path.join(config.installPath, "resources", "app")
+        : config.installPath;
+
+    if(!fs.existsSync(root)) {
+        console.error(`Foundry install path '${root}' does not exist.`);
+        return;
     }
 
-    try {
-        await fs.promises.mkdir("foundry");
-    } catch (e) {
-        if (e.code !== "EEXIST") throw e;
+    return root;
+}
+
+/**
+ * @param {string} dirName 
+ */
+async function createDestinationRootDir(dirName) {
+    await fs.promises.mkdir(dirName, { recursive: true });
+}
+
+/**
+ * @param {string} targetPath 
+ * @param {string} symlinkPath 
+ */
+async function canCreateSymlink(targetPath, symlinkPath) {
+    const stat = await fs.promises.lstat(symlinkPath, { throwIfNoEntry: false });
+
+    // Is the path empty?
+    if(!stat) return true;
+
+    // Is it a non-symlink file/dir?
+    if(!stat.isSymbolicLink()) {
+        console.error(`Unable to create symlink because file/directory exists at: ${symlinkPath}`);
+        console.error("Remove existing file/directory and run this script again.");
+        return false;
     }
 
-    // Javascript files
-    for (const p of ["client", "common", "tsconfig.json"]) {
-        try {
-            await fs.promises.symlink(path.join(fileRoot, p), path.join("foundry", p));
-        } catch (e) {
-            if (e.code !== "EEXIST") throw e;
-        }
-    }
+    // Is existing symlink correct?
+    const currentTarget = await fs.promises.readlink(symlinkPath);
+    const absoluteCurrent = path.resolve(path.dirname(symlinkPath), currentTarget); // Resolve paths to handle both absolute and relative targets accurately
+    const absoluteTarget = path.resolve(targetPath);
+    if(absoluteCurrent === absoluteTarget) return false;
 
-    // Language files
-    try {
-        await fs.promises.symlink(path.join(fileRoot, "public", "lang"), path.join("foundry", "lang"));
-    } catch (e) {
-        if (e.code !== "EEXIST") throw e;
-    }
-} else {
-    console.log("Foundry config file did not exist.");
+
+    console.log(`Unlinking existing symlink: ${symlinkPath}`);
+    await fs.promises.unlink(symlinkPath);
+
+    return true;
 }

--- a/tools/create-foundry-symlinks.mjs
+++ b/tools/create-foundry-symlinks.mjs
@@ -1,116 +1,70 @@
 /* eslint-disable jsdoc/require-jsdoc */
 import * as fs from "fs";
-import yaml from "js-yaml";
-import path from "path";
+import path, { dirname } from "path";
+import { parseArgs } from "util";
 
-/*
-    Env vars:
-    "foundry-config-path": string (default "foundry-config.yaml")
-    "dest-root-dir": string (default "foundry")
-*/
-await execute()
+const DEST_ROOT_DIR = "foundry";  // Hardcoded because it's referenced in jsconfig
+const ABORT = "abort";
 
-async function execute() {
+await (async () => {
     process.exitCode = 1;
 
-    const options = getEnvOptions();
+    const options = getOptions();
+    if(!options) return;
 
-    const config = await loadConfig(options.foundryConfigPath);
-    if(!config) return;
+    const sourceRootDir = getSourceRootDir(options.installPath);
+    if(!sourceRootDir) return;
 
-    const sourceRootDir = getSourceRootDir(config);
-    if(!sourceRootDir) return false;
+    // Create destinatin dir if it doesn't already exist.
+    await fs.promises.mkdir(DEST_ROOT_DIR, { recursive: true });
 
-    await createDestinationRootDir(options.destRootDir);
-    await linkJsFiles(sourceRootDir, options.destRootDir);
-    await linkLangFiles(sourceRootDir, options.destRootDir);
+    // Link JS files
+    for(const p of ["client", "common", "tsconfig.json"]) {
+        const targetPath = path.join(sourceRootDir, p);
+        const symlinkPath = path.join(DEST_ROOT_DIR, p);
+
+        if(await tryCreateSymlink(targetPath, symlinkPath) === ABORT) return;
+    }
+
+    // Link Lang files
+    const targetPath = path.join(sourceRootDir, "public", "lang");
+    const symlinkPath = path.join(DEST_ROOT_DIR, "lang");
+
+    if(await tryCreateSymlink(targetPath, symlinkPath) === ABORT) return;
 
     console.log("Successfully created foundry symlinks.");
     process.exitCode = 0;
-}
+})();
 
-/**
- * @typedef {object} EnvOptions
- * @property {string} foundryConfigPath
- * @property {string} destRootDir
- */
 
-function getEnvOptions() {
-    const foundryConfigPath = process.env.npm_config_foundry_config_path ?? "foundry-config.yaml";
-    const destRootDir = process.env.npm_config_dest_root_dir ?? "foundry";
+function getOptions() {
+    const { values: parsedArgs } = parseArgs({ 
+        options: {
+            'foundry-install-path': { type: "string" }
+        }
+    });
 
-    /** @type {EnvOptions} */
-    const options = {
-        foundryConfigPath,
-        destRootDir
+    const opts = {
+        installPath: parsedArgs["foundry-install-path"]
     }
 
-    return options
-}
+    if(!opts.installPath) return console.error("Missing required argument '--foundry-install-path=<string>'");
+    if(!fs.existsSync(opts.installPath)) return console.error(`Foundry install path does not exist: ${opts.installPath}`);
 
-/**
- * @param {string} sourceRootDir 
- * @param {string} destRootDir
- */
-async function linkJsFiles(sourceRootDir, destRootDir) {
-    for(const p of ["client", "common", "tsconfig.json"]) {
-        const targetPath = path.join(sourceRootDir, p);
-        const symlinkPath = path.join(destRootDir, p);
-
-        const canCreate = await canCreateSymlink(targetPath, symlinkPath)
-        if(canCreate) await createSymlink(targetPath, symlinkPath);
-    }
-}
-
-async function linkLangFiles(sourceRootDir, destRootDir) {
-    const targetPath = path.join(sourceRootDir, "public", "lang");
-    const symlinkPath = path.join(destRootDir, "lang");
-
-    const canCreate = await canCreateSymlink(targetPath, symlinkPath)
-    if(canCreate) await createSymlink(targetPath, symlinkPath);
-}
-
-async function createSymlink(targetPath, symlinkPath) {
-    await fs.promises.symlink(targetPath, symlinkPath);
-    console.log(`Symlinked: ${symlinkPath} -> ${targetPath}`);
+    return opts;
 }
 
 
 /**
- * @typedef {object} Config
- * @property {string} installPath
+ * @param {string} foundryInstallPath 
  */
-
-/**
- * @param {string} configYamlPath 
- */
-async function loadConfig(configYamlPath) {
-    if(!fs.existsSync(configYamlPath)) {
-        console.error(`Config yaml file '${configYamlPath}' not found.`);
-        return;
-    }
-
-    try {
-        const fc = await fs.promises.readFile(configYamlPath, "utf-8");
-
-        /** @type {Config} */
-        const foundryConfig = yaml.load(fc);
-        return foundryConfig
-    } catch (err) {
-        console.error(`Error reading ${configYamlPath}: ${err}`);
-    }
-}
-
-/**
- * @param {Config} config 
- */
-function getSourceRootDir(config) {
+function getSourceRootDir(foundryInstallPath) {
     // As of 13.338, the Node install is not nested but electron installs are
-    const isNested = fs.existsSync(path.join(config.installPath, "resources", "app"));
+    const isNested = fs.existsSync(path.join(foundryInstallPath, "resources", "app"));
 
     const root = isNested 
-        ? path.join(config.installPath, "resources", "app")
-        : config.installPath;
+        ? path.join(foundryInstallPath, "resources", "app")
+        : foundryInstallPath;
 
     if(!fs.existsSync(root)) {
         console.error(`Foundry install path '${root}' does not exist.`);
@@ -121,38 +75,31 @@ function getSourceRootDir(config) {
 }
 
 /**
- * @param {string} dirName 
- */
-async function createDestinationRootDir(dirName) {
-    await fs.promises.mkdir(dirName, { recursive: true });
-}
-
-/**
  * @param {string} targetPath 
- * @param {string} symlinkPath 
+ * @param {string} symlinkPath
  */
-async function canCreateSymlink(targetPath, symlinkPath) {
+async function tryCreateSymlink(targetPath, symlinkPath) {
     const stat = await fs.promises.lstat(symlinkPath, { throwIfNoEntry: false });
 
-    // Is the path empty?
-    if(!stat) return true;
+    // Does the path already exist?
+    if(stat) {
+        // Is it a non-symlink file/dir?
+        if(!stat.isSymbolicLink()) {
+            console.error(`Unable to create symlink because file/directory exists at: ${symlinkPath}`);
+            console.error("Remove existing file/directory and run this script again.");
+            return ABORT;
+        }
 
-    // Is it a non-symlink file/dir?
-    if(!stat.isSymbolicLink()) {
-        console.error(`Unable to create symlink because file/directory exists at: ${symlinkPath}`);
-        console.error("Remove existing file/directory and run this script again.");
-        return false;
+        // Is the existing symlink already correct?
+        const currentTarget = await fs.promises.readlink(symlinkPath);
+        const absoluteCurrent = path.resolve(path.dirname(symlinkPath), currentTarget); // Resolve paths to handle both absolute and relative targets accurately
+        const absoluteTarget = path.resolve(targetPath);
+        if(absoluteCurrent === absoluteTarget) return;
+
+        console.log(`Unlinking existing symlink: ${symlinkPath}`);
+        await fs.promises.unlink(symlinkPath);
     }
 
-    // Is existing symlink correct?
-    const currentTarget = await fs.promises.readlink(symlinkPath);
-    const absoluteCurrent = path.resolve(path.dirname(symlinkPath), currentTarget); // Resolve paths to handle both absolute and relative targets accurately
-    const absoluteTarget = path.resolve(targetPath);
-    if(absoluteCurrent === absoluteTarget) return false;
-
-
-    console.log(`Unlinking existing symlink: ${symlinkPath}`);
-    await fs.promises.unlink(symlinkPath);
-
-    return true;
+    await fs.promises.symlink(targetPath, symlinkPath);
+    console.log(`Symlinked: ${symlinkPath} -> ${targetPath}`);
 }


### PR DESCRIPTION
closes #26

Verifies compatibility with Foundry v14, updates dependencies, and improves dev tooling.

## Changes
- **`module.json`** - Updated verified and maximum compatibility for v14.
- **`jsconfig.json`** - Updated for node version compatibility.
- **`create-foundry-symlinks`** - Refactored to receive foundry installation directory path via command line argument instead of through the previous (undocumented) `foundry-config.yaml` file, improved error handling, and restructured for clarity.
- **`README`** - Added "Development Scripts" section documenting the refactored `npm run createFoundrySymlinks` command.
- **Dependencies** - Added `@types/node` dev dependency.